### PR TITLE
Software Breakpoints

### DIFF
--- a/H3Randomizer_CPP/H3Randomizer_CPP.vcxproj
+++ b/H3Randomizer_CPP/H3Randomizer_CPP.vcxproj
@@ -32,7 +32,7 @@
     <ProjectGuid>{cdc21f21-25c1-422c-a720-a5f25d904a40}</ProjectGuid>
     <RootNamespace>H3RandomizerCPP</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-    <ProjectName>H3Randomizer_CPP</ProjectName>
+    <ProjectName>PyDebugger_CPP</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
IMPORTANT: Software Breakpoints are not nearly as fast/efficient as hardware breakpoints, so it's important that code is optimized for such cases. A new pull request will be opened at some point with relevant optimizations to h3randomizer.py, this PR only implements the ability to use software breakpoints. As a note, randomize_char_weapons is currently using software breakpoints and while it has been significantly optimized, this is not release ready.
General Notes:
- Generalizing `H3Randomizer_CPP` -> `PyDebugger_CPP` for eventual divorce of the projects; PyDebugger can be a useful binding for projects outside of H3 (or randomizing halo in general), so I'd like to eventually create it as a separate project when it's more fleshed out.
- Software breakpoints have been implemented into `PyDebugger_CPP`, and hardware and software breakpoints now have separate functions to create; create_hardware_breakpoint and create_software_breakpoint
- Changed nomenclature for PyDebugger_CPP.DebugHandler breakpoints, now there is a separate function for creating and actually setting the breakpoints.
- See commit notes for more details